### PR TITLE
fix-bugs

### DIFF
--- a/SPT Mobile.xcodeproj/project.pbxproj
+++ b/SPT Mobile.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		2C4357C92C84D07E0063D8A2 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4357C82C84D07E0063D8A2 /* NetworkManager.swift */; };
 		2C4357CB2C84D0A90063D8A2 /* ModelForCurrentLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4357CA2C84D0A90063D8A2 /* ModelForCurrentLocation.swift */; };
 		2C4357CF2C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4357CD2C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.swift */; };
-		2C4357D02C84E0B30063D8A2 /* HeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2C4357CE2C84E0B30063D8A2 /* HeaderTableViewCell.xib */; };
+		2C4357D02C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2C4357CE2C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.xib */; };
 		2C4357D22C84E6E10063D8A2 /* PlanViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4357D12C84E6E10063D8A2 /* PlanViewData.swift */; };
 		2C4357D52C84E97A0063D8A2 /* SearchLocationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4357D32C84E97A0063D8A2 /* SearchLocationTableViewCell.swift */; };
 		2C4357D62C84E97A0063D8A2 /* SearchLocationTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2C4357D42C84E97A0063D8A2 /* SearchLocationTableViewCell.xib */; };
@@ -84,7 +84,7 @@
 		2C4357C82C84D07E0063D8A2 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		2C4357CA2C84D0A90063D8A2 /* ModelForCurrentLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelForCurrentLocation.swift; sourceTree = "<group>"; };
 		2C4357CD2C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionHeaderTableViewCell.swift; sourceTree = "<group>"; };
-		2C4357CE2C84E0B30063D8A2 /* HeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeaderTableViewCell.xib; sourceTree = "<group>"; };
+		2C4357CE2C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ConnectionHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		2C4357D12C84E6E10063D8A2 /* PlanViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanViewData.swift; sourceTree = "<group>"; };
 		2C4357D32C84E97A0063D8A2 /* SearchLocationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLocationTableViewCell.swift; sourceTree = "<group>"; };
 		2C4357D42C84E97A0063D8A2 /* SearchLocationTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchLocationTableViewCell.xib; sourceTree = "<group>"; };
@@ -168,7 +168,7 @@
 				2C4357D32C84E97A0063D8A2 /* SearchLocationTableViewCell.swift */,
 				2C4357D42C84E97A0063D8A2 /* SearchLocationTableViewCell.xib */,
 				2C4357CD2C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.swift */,
-				2C4357CE2C84E0B30063D8A2 /* HeaderTableViewCell.xib */,
+				2C4357CE2C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.xib */,
 				2C4357D72C84EA190063D8A2 /* UpcomingTableViewCell.swift */,
 				2C4357D82C84EA190063D8A2 /* UpcomingTableViewCell.xib */,
 				2C4357DB2C84EA290063D8A2 /* ErrorTableViewCell.swift */,
@@ -392,7 +392,7 @@
 				2C4357DA2C84EA190063D8A2 /* UpcomingTableViewCell.xib in Resources */,
 				2C4357D62C84E97A0063D8A2 /* SearchLocationTableViewCell.xib in Resources */,
 				2C4E65352C7BC02E0088F7AB /* StarterView.xib in Resources */,
-				2C4357D02C84E0B30063D8A2 /* HeaderTableViewCell.xib in Resources */,
+				2C4357D02C84E0B30063D8A2 /* ConnectionHeaderTableViewCell.xib in Resources */,
 				2C71B0F72C85104000B1CB33 /* LoaderTableViewCell.xib in Resources */,
 				2C4E65402C7BC4380088F7AB /* LocationView.xib in Resources */,
 				2C4E653B2C7BC0F40088F7AB /* StarterInfoView.xib in Resources */,

--- a/SPT Mobile/Controller/PlanViewController.swift
+++ b/SPT Mobile/Controller/PlanViewController.swift
@@ -47,7 +47,7 @@ class PlanViewController: UIViewController {
     private func registerXib() {
         let nibNames = [
             "SearchLocationTableViewCell",
-            "HeaderTableViewCell",
+            "ConnectionHeaderTableViewCell",
             "UpcomingTableViewCell",
             "ErrorTableViewCell",
             "LoaderTableViewCell",

--- a/SPT Mobile/Managers/TableViewCellManager.swift
+++ b/SPT Mobile/Managers/TableViewCellManager.swift
@@ -38,7 +38,7 @@ extension TableViewCellManager {
     
     /// Private Methods for Fetching State: Cell Configuration
     private func headerCellConfigurationWhileFetching(in tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "HeaderTableViewCell", for: indexPath) as! ConnectionHeaderTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ConnectionHeaderTableViewCell", for: indexPath) as! ConnectionHeaderTableViewCell
         tableView.separatorStyle = .none
         cell.updateWhileLoading()
         return cell
@@ -61,7 +61,6 @@ extension TableViewCellManager {
     }
 }
 
-
 // MARK: -  Methods for Updating Date
 extension TableViewCellManager {
     func cellForRowWhileUpdatingData(in tableView: UITableView, at indexPath: IndexPath, planViewData: PlanViewData) -> UITableViewCell {
@@ -79,7 +78,7 @@ extension TableViewCellManager {
     
     /// Private Methods for Updating Data State: Cell Configuration
     private func headerCellConfigurationWithData(in tableView: UITableView, at indexPath: IndexPath, from: PlanViewData) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "HeaderTableViewCell", for: indexPath) as! ConnectionHeaderTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ConnectionHeaderTableViewCell", for: indexPath) as! ConnectionHeaderTableViewCell
         tableView.separatorStyle = .singleLine
         cell.updateResponse(from: from)
         return cell
@@ -103,7 +102,6 @@ extension TableViewCellManager {
         }
     }
 }
-
 
 // MARK: - Methods for Showing Error
 extension TableViewCellManager {
@@ -131,7 +129,7 @@ extension TableViewCellManager {
     
     /// Private Methods for Error State: Cell Configuration
     private func headerCellWithError(in tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "HeaderTableViewCell") as! ConnectionHeaderTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ConnectionHeaderTableViewCell") as! ConnectionHeaderTableViewCell
         tableView.separatorStyle = .none
         cell.updateError()
         return cell

--- a/SPT Mobile/View/Timetable/Cells/ConnectionHeaderTableViewCell.swift
+++ b/SPT Mobile/View/Timetable/Cells/ConnectionHeaderTableViewCell.swift
@@ -19,7 +19,9 @@ class ConnectionHeaderTableViewCell: UITableViewCell {
     }
     
     func updateResponse(from: PlanViewData) {
-        currentLocationLbl.text = from.legs?.first?.terminal
+        DispatchQueue.main.async { [self] in
+            currentLocationLbl.text = from.legs?.first?.terminal
+        }
         fromLbl.text = "From"
         directionLbl.text = "Direction"
     }

--- a/SPT Mobile/View/Timetable/Cells/ConnectionHeaderTableViewCell.xib
+++ b/SPT Mobile/View/Timetable/Cells/ConnectionHeaderTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="HeaderTableViewCell" rowHeight="85" id="KGk-i7-Jjw" customClass="ConnectionHeaderTableViewCell" customModule="SPT_Mobile" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ConnectionHeaderTableViewCell" rowHeight="85" id="KGk-i7-Jjw" customClass="ConnectionHeaderTableViewCell" customModule="SPT_Mobile" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="393" height="87"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/SPT Mobile/View/Timetable/TimetableView.swift
+++ b/SPT Mobile/View/Timetable/TimetableView.swift
@@ -36,6 +36,16 @@ class TimetableView: UIView, UIGestureRecognizerDelegate {
         commonInit()
     }
     
+    @IBAction private func fromFieldRemoverTap(_ sender: Any) {
+        clearFromField()
+        planViewController?.removeSearchResults()
+    }
+    
+    @IBAction private func toFieldRemoverTap(_ sender: Any) {
+        clearToField()
+        planViewController?.removeSearchResults()
+    }
+    
     // MARK: - Setup Methods
     
     private func commonInit() {
@@ -77,11 +87,20 @@ class TimetableView: UIView, UIGestureRecognizerDelegate {
          scrollView.addGestureRecognizer(tapGesture)
      }
      
-     // Delegate method to ensure the gesture recognizer doesn't block table view interactions
-     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-         // Only dismiss the keyboard if the tap is outside the table view
-         return !connectionTableView.frame.contains(touch.location(in: self))
-     }
+    // Delegate method to ensure the gesture recognizer doesn't block table view interactions
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        // Check if the touch location is inside the table view
+        let location = touch.location(in: self.connectionTableView)
+        
+        // Allow gestures only if the touch is outside any table view cell or any scrollable content
+        if let indexPath = connectionTableView.indexPathForRow(at: location) {
+            // If the touch is on a cell, don't trigger the gesture recognizer
+            return false
+        }
+        
+        // Allow gesture if touch is not within the table view's frame
+        return true
+    }
 
      @objc private func dismissKeyboard() {
          fromField.resignFirstResponder()
@@ -149,16 +168,6 @@ class TimetableView: UIView, UIGestureRecognizerDelegate {
     
     private func clearToField() {
         toField.text = ""
-    }
-    
-    @IBAction private func fromFieldRemoverTap(_ sender: Any) {
-        clearFromField()
-        planViewController?.removeSearchResults()
-    }
-    
-    @IBAction private func toFieldRemoverTap(_ sender: Any) {
-        clearToField()
-        planViewController?.removeSearchResults()
     }
     
     // MARK: - Reset View Appearance After Gesture


### PR DESCRIPTION
### **Fix Tap Gesture Blocking TableView Interactions**

This branch resolves an issue where the tap gesture recognizer was blocking interactions with the last cell of the `connectionTableView`. The fix ensures that the tap gesture only dismisses the keyboard when the user taps outside of the table view cells.

#### **Changes:**
- Updated the `gestureRecognizer(_:shouldReceive:)` method to prevent the tap gesture from intercepting touches inside the `connectionTableView` cells.
- The gesture recognizer now checks if the touch is within a table view cell and only allows the tap gesture to be triggered when the touch occurs outside the table view.
